### PR TITLE
Startup code

### DIFF
--- a/main/Core/Globals.cpp
+++ b/main/Core/Globals.cpp
@@ -142,3 +142,7 @@ CDisplayInterface* gpDisplayInterface = (CDisplayInterface*)kpNULL;
 // Shared display memory pointer.
 
 volatile void* gpDisplayMemory = kpNULL;    // Gets filled in by TclGrammerApp.
+
+// This variable is true if SpecTcl was built for MPI and is run under MPI
+
+bool          gMPIParallel(false);

--- a/main/Core/Globals.h
+++ b/main/Core/Globals.h
@@ -58,5 +58,6 @@ extern CAnalyzer*          gpAnalyzer;          // Points to event analyzer.
 extern const char*         gpVersion;           // SpecTcl version text.
 extern CDisplayInterface*  gpDisplayInterface;  // Display interface
 extern volatile void*               gpDisplayMemory;     // Display memory.
+extern bool                gMPIParallel;       // TRUE if built with MPI and run with MPIRUN.
 
 #endif

--- a/main/Core/SpecTclMain.cpp
+++ b/main/Core/SpecTclMain.cpp
@@ -39,7 +39,7 @@ extern char** SpecTclArgv;
  *
  * \param argc
  * \param argv
- * \return
+ * \return status
  */
 int main(int argc, char* argv[]) {
     SpecTclArgc = argc;

--- a/main/Core/TclGrammerApp.h
+++ b/main/Core/TclGrammerApp.h
@@ -112,6 +112,7 @@ private:
   
   int m_nUpdateRate;
   Tcl_ThreadId              m_nMainThread;
+  int                       m_mpiRank;    ///!< The world rank when running under MPI:
  public:
   //Default constructor alternative to compiler provided default constructor
   //Ensure correct initial values
@@ -376,6 +377,10 @@ private:
    * \return TCL_OK
    */
   static int AppInit(Tcl_Interp* pInterp);
+
+  /** MPIAppInit - application initialization but for MPI parallel SpecTcl: */
+
+  static int MPIAppInit(Tcl_Interp* pInterp);
 };
 
 #endif

--- a/main/configure.ac
+++ b/main/configure.ac
@@ -23,6 +23,39 @@ AC_CONFIG_MACRO_DIR([m4])
 AC_EXEEXT
 AC_OBJEXT
 
+
+##
+#  SpecTcl 7  - the point of this version is to support 
+#               MPI parallelism.
+#  we add two new flags to configure for this:
+#    --enable-mpi  - Defines WITH_MPI in config.h
+#    --with-mpicxx - Defines a location out of path for the mpicxx compiler driver.
+#
+AC_ARG_ENABLE([mpi], 
+  [AS_HELP_STRING([--enable-mpi],[Enable MPI parallel SpecTcl, see the --with-mpicxx flag as well])],
+  [mpi_enabled=1], [mpi_enabled=0])
+AC_ARG_WITH([mpicxx], 
+  [AS_HELP_STRING([--with-mpicxx],[Provide the path to the MPI C++ driver (defaults to 'mpicxx')])], 
+  [mpicxx=${withval}], [mpicxx="mpicxx"])
+
+AC_MSG_NOTICE([MPI: mpi_enabled = ${mpi_enabled}])
+
+# Establish the C++ compiler dependingon MPI or not.
+
+if test "${mpi_enabled}" = "1" 
+then
+  AC_DEFINE([WITH_MPI],[],[Enable MPI Parallel build])   # Add WITH_MPI to config.h
+  AC_MSG_NOTICE([MPI parallel SpecTcl is enabled -- setting compiler])
+  AC_MSG_NOTICE([Trying to use ${mpicxx} for the MPI compiler driver])
+  AC_CHECK_FILE([${mpicxx}], [CXX=${mpicxx}], [AC_MSG_ERROR([${mpicxx} does not exist check your --with-mpicxx value])])
+  AC_PROG_CXX(${mpicxx})
+else
+  AC_MSG_NOTICE(["Building serial SpecTcl only])
+  AC_PROG_CXX
+fi
+
+# Require C++11 support:
+
 AX_CXX_COMPILE_STDCXX_11([noext])
 
 # we use libtool, thus we need to include it
@@ -40,7 +73,6 @@ SOVERSION="4:0"
 
 
 AC_PROG_AWK
-AC_PROG_CXX
 AC_PROG_CC
 AC_PROG_CPP
 AC_PROG_INSTALL
@@ -781,6 +813,9 @@ fi
 #  There's a utility that uses gengetopt:
 
 AX_GENGETOPT
+
+
+
 
 ##
 # Check for zlib for the zip/unzip commands.

--- a/main/configure.ac
+++ b/main/configure.ac
@@ -47,6 +47,7 @@ if test "${mpi_enabled}" = "1"
 then
   CC=${mpicc}
   CXX=${mpicxx}
+  AC_DEFINE(WITH_MPI, 1, [MPI Parallel SpecTcl])
   AC_MSG_NOTICE([Building MPI enabled SpecTcl using ${mpicc} and ${mpicxx} as compiler drivers])
 else 
   AC_MSG_NOTICE([Building Serial SpecTcl])

--- a/main/configure.ac
+++ b/main/configure.ac
@@ -32,31 +32,51 @@ AC_OBJEXT
 #    --with-mpicxx - Defines a location out of path for the mpicxx compiler driver.
 #
 AC_ARG_ENABLE([mpi], 
-  [AS_HELP_STRING([--enable-mpi],[Enable MPI parallel SpecTcl, see the --with-mpicxx flag as well])],
+  [AS_HELP_STRING([--enable-mpi],[Enable MPI parallel SpecTcl, see the --with-mpicxx, --with-mpicc flags as well])],
   [mpi_enabled=1], [mpi_enabled=0])
 AC_ARG_WITH([mpicxx], 
   [AS_HELP_STRING([--with-mpicxx],[Provide the path to the MPI C++ driver (defaults to 'mpicxx')])], 
   [mpicxx=${withval}], [mpicxx="mpicxx"])
-
-AC_MSG_NOTICE([MPI: mpi_enabled = ${mpi_enabled}])
+AC_ARG_WITH([mpicc],
+  [AS_HELP_STRING([--with-mpicc], [Provide the path to the MPI C driver (defaults to 'mpicc')])],
+  [mpicc=${withval}], [mpicc="mpicc"])
 
 # Establish the C++ compiler dependingon MPI or not.
 
 if test "${mpi_enabled}" = "1" 
 then
-  AC_DEFINE([WITH_MPI],[],[Enable MPI Parallel build])   # Add WITH_MPI to config.h
-  AC_MSG_NOTICE([MPI parallel SpecTcl is enabled -- setting compiler])
-  AC_MSG_NOTICE([Trying to use ${mpicxx} for the MPI compiler driver])
-  AC_CHECK_FILE([${mpicxx}], [CXX=${mpicxx}], [AC_MSG_ERROR([${mpicxx} does not exist check your --with-mpicxx value])])
-  AC_PROG_CXX(${mpicxx})
-else
-  AC_MSG_NOTICE(["Building serial SpecTcl only])
-  AC_PROG_CXX
+  CC=${mpicc}
+  CXX=${mpicxx}
+  AC_MSG_NOTICE([Building MPI enabled SpecTcl using ${mpicc} and ${mpicxx} as compiler drivers])
+else 
+  AC_MSG_NOTICE([Building Serial SpecTcl])
+fi
+
+AC_PROG_CC([${CC} gcc cc])
+AC_PROG_CXX([${CXX} g++ c++])
+
+# Be sure we found the mpi compiler drivers if necessary:
+
+if test "${mpi_enabled}" = "1"
+then
+  mpi_ctail=`basename ${mpicc}`
+  actual_ctail=`basename ${CC}`
+  if test ${mpi_ctail} != ${actual_ctail}
+  then
+    AC_MSG_ERROR([Got C compiler ${CC} instead of ${mpicc} check your --with-mpicc value])
+  fi
+  mpi_cxxtail=`basenme ${mpicxx}`
+  actual_cxxtail=`basename ${CXX}`
+  if test ${mpi_cxxtail} != ${actual_cxxtail}
+  then
+    AC_MSG_ERROR([Got C++ compiler ${CXX} instead of ${mpicxx} check your --with-mpicxx value])
+  fi
 fi
 
 # Require C++11 support:
 
 AX_CXX_COMPILE_STDCXX_11([noext])
+
 
 # we use libtool, thus we need to include it
 LT_INIT
@@ -73,7 +93,6 @@ SOVERSION="4:0"
 
 
 AC_PROG_AWK
-AC_PROG_CC
 AC_PROG_CPP
 AC_PROG_INSTALL
 AC_PROG_LN_S


### PR DESCRIPTION
*  Make SpecTcl understand MPI builds via configuration options:
    - --enable-mpi  - turns on WITH_MPI in config.h
    -  --with-mpicc - Sets path to the mpicc compiler.
    - --with-mpicxx - sets path to the mpicxx compiler
* Make the start up code do different things if it's under mpirun with the mpi enabled than it would in serial mode.